### PR TITLE
Update link format using base64url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ It describes how to represent transaction data into a simple link, which can be 
 So everything a user needs to do to send a transaction is to click on the link or scan QR code.  
 
 Example:
-`https://bip.to/tx?d=f8bb4601018...5f8431ba0`
+`https://bip.to/tx/-DsEqumKTVBSTwAAAAAAAIiKxyMEiegAAIpCSVAAAAAAAAAAiQFa8deLWMQAAItIZWxsbyBXb3JsZICAgA`
 
 - `https://bip.to` - URL
-- `tx` - action
+- `tx/{data}` - action
 
-#### Params
-- `d` - tx-like data. [RLP-encoded](https://github.com/ethereum/wiki/wiki/RLP) structure in hex format:
+#### URL params
+- `{data}` - tx-like data. [RLP-encoded](https://github.com/ethereum/wiki/wiki/RLP) structure in [base64url](https://base64.guru/standards/base64url) format:
 ```golang
 type Data struct {  
   Type      byte
@@ -27,13 +27,14 @@ Optional fields should be kept in the RLP structure but may have value of empty 
 
 Data field is the same as Data of Minter transaction. It is described in the [docs](https://docs.minter.network/#section/Transactions)
 
-- `p` - password of the check. RLP-encoded bytes array. If you want to make reedeem check link and you don't know address of recipient than you can't make check's proof. In this case you can leave Proof field empty and pass raw password in this param.
+#### Query params
+
+- `p={password}` - password of the check. base64url-encoded bytes array. If you want to make reedeem check link and you don't know address of recipient than you can't make check's proof. In this case you can leave Proof field empty and pass raw password in this param.
 
 Example:
-`https://bip.to/tx?d=f8bb4601018...5f8431ba0?p=83313233`
+`https://bip.to/tx/-LEJ...AgIA?p=MTIz`
 
 #### Native app implementation notes
 
-Native wallet app should: 
-- be associated with [bip.to](https://bip.to) website with Universal/App Links protocol;
-- fallback to custom URL scheme: `minter://`, eg. `bip.to/tx?d=..` => `minter:///tx?d=..`;
+Native wallet app should be associated with [bip.to](https://bip.to) website with Universal/App Links protocol;
+


### PR DESCRIPTION
- move `tx?d={data}` query param to url param `tx/{data}` because it is required and we can save few bytes
- change format of RLP `data` bytes to base64url encoding instead of hex, because it is more efficient
- change encoding of `password` param to base64url instead of hex RLP, it's more efficient